### PR TITLE
Allow component instantiation from a passed-in object.

### DIFF
--- a/docs/component.md
+++ b/docs/component.md
@@ -65,12 +65,21 @@ Component type exposes some properties. All of these are read-only.
 Once you have component type, you can instantiate it with `new` keyword.
 
 ```js
+	var building = new cBuilding({
+		floors: 2,
+		height: 8
+	});
+```
+
+or
+
+```js
 	var building = new cBuilding();
 	building.floors = 5;
 	building.height = 10;
 ```
 
-Data in the component should be set explicitly like shown. You don't need to set all properties and you cannot set properties you haven't defined for the component type. Those will be silently ignored and thrown away.
+You don't need to set all properties and you cannot set properties you haven't defined for the component type. Those will be silently ignored and thrown away.
 
 ### Dynamically set data
 

--- a/src/component.coffee
+++ b/src/component.coffee
@@ -184,6 +184,8 @@ initializeData = (component, fields, data) ->
 	if data and _.isArray data
 		data.length = fields.length
 		component[ bData ] = data
+	else if data and _.isPlainObject data
+		component[ bData ] = _.map fields, (field) -> data[field]
 	else
 		component[ bData ] = new Array(fields.length)
 	return

--- a/test/component.test.coffee
+++ b/test/component.test.coffee
@@ -205,6 +205,18 @@ describe 'Component', ->
 			expect(component.test2).to.equal 20
 			expect(component.test3).to.not.be.ok
 
+		it 'should set values based on object passed into constructor function', ->
+			component = @cComponent { x: 5, test1: 10, test2: 20, test3: 30 }
+			expect(component.test1).to.equal 10
+			expect(component.test2).to.equal 20
+			expect(component.test3).to.equal 30
+
+		it 'should keep remaining values undefined when passed object is shorter', ->
+			component = @cComponent { x: 5, test1: 10, test2: 20 }
+			expect(component.test1).to.equal 10
+			expect(component.test2).to.equal 20
+			expect(component.test3).to.not.be.ok
+
 		describe '@@changed', ->
 
 			beforeEach ->


### PR DESCRIPTION
How do you feel about allowing components to be initialized from an object?

e.g. instead of:

``` js
    var building = new cBuilding();
    building.floors = 5;
    building.height = 10;
```

we could use:

``` js
    var building = new cBuilding({
        floors: 2,
        height: 8
    });
```

It's a bit shorter than the first syntax and doesn't interfere with the Array syntax (`var building = new cBuilding([2, 8])`).
