### PR TITLE
Adding existing entity to engine (issue #8)

### DIFF
--- a/docs/engine.md
+++ b/docs/engine.md
@@ -92,16 +92,32 @@ You can also use `onAdded` and `onRemoved` method to register your handlers. The
 
 ## Entity management
 
-Engine keeps the list of all entities for you. It also automatically informs existing node types about these. All you need to do is call method `addEntity`.
+Engine keeps the list of all entities for you. It also automatically informs existing node types about these. All you need to do is call method `buildEntity`.
 
 ```js
 	var building, foundation;
-	var eCorporateBuilding = engine.addEntity([
+	var eCorporateBuilding = engine.buildEntity([
 		building = new cBuilding,
 		foundation = new cFoundation
 	]);
 	building.floors = 10;
 	foundation.material = 'stone';
+```
+
+You can also add existing entities with `addEntity`.
+
+```js
+	var building = new cBuilding;
+	building.floors = 10;
+
+	var foundation = new cFoundation;
+	foundation.material = 'stone';
+
+	var eCorporateBuilding = new Scent.Entity();
+	eCorporateBuilding.add(building);
+	eCorporateBuilding.add(foundation);
+
+	engine.addEntity(eCorporateBuilding);
 ```
 
 There is no direct method for removal of entity from engine. Instead when you call `entity.dispose()`, it will eventually remove entity from engine as well.

--- a/readme.md
+++ b/readme.md
@@ -82,7 +82,7 @@ Following is small example how simply you can create game mechanics to close doo
 
 	var door = new cDoor()
 	door.material = 'wood';
-	var eDoor = engine.addEntity([door]);
+	var eDoor = engine.buildEntity([door]);
 
 	engine.onAction('doorOpen', function(action) {
 		var eDoor = action.data;

--- a/src/engine.coffee
+++ b/src/engine.coffee
@@ -32,12 +32,19 @@ Engine = (initializer) ->
 
 	engine.entityList = Lill.attach {}
 
-	# Only method to add entity to engine
-	engine.addEntity = (components) ->
-		entity = Entity components
+	# Add existing entity to engine
+	engine.addEntity = (entity) ->
+		if entity instanceof Array
+			log 'Passing array of components to addEntity method is deprecated. Use buildEntity method instead.'
+			entity = new Entity entity
+
 		Lill.add engine.entityList, entity
 		addedEntities.push entity
 		return entity
+
+	# Build entity from array of components
+	engine.buildEntity = (components) ->
+		engine.addEntity new Entity components
 
 	Object.defineProperty engine, 'size', get: ->
 		Lill.getSize engine.entityList

--- a/test/engine.test.coffee
+++ b/test/engine.test.coffee
@@ -1,5 +1,6 @@
 {expect, sinon, resetComponentIdentities, mockSystem} = require './setup'
 Engine = require '../src/engine'
+Entity = require '../src/entity'
 Component = require '../src/component'
 symbols = require '../src/symbols'
 
@@ -73,11 +74,11 @@ describe 'Engine', ->
             expect(nTest1).to.not.equal nTest3
 
         it 'should fill node type with existing entities', ->
-            firstEntity = @engine.addEntity [
+            firstEntity = @engine.buildEntity [
                 new @cAlphaComponent
                 new @cGamaComponent
             ]
-            secondEntity = @engine.addEntity [
+            secondEntity = @engine.buildEntity [
                 new @cAlphaComponent
                 new @cBetaComponent
             ]
@@ -93,19 +94,46 @@ describe 'Engine', ->
         it 'should be a function', ->
             expect(@engine).to.respondTo 'addEntity'
 
+        it 'should accept existing entity', ->
+            alpha = new @cAlphaComponent
+            beta = new @cBetaComponent
+            entity = new Entity [alpha, beta]
+            @engine.addEntity entity
+
+            expect(Lill.has @engine.entityList, entity).to.be.true
+            entity.dispose()
+
+        it 'should return same entity', ->
+            alpha = new @cAlphaComponent
+            beta = new @cBetaComponent
+            entity = new Entity [alpha, beta]
+            entity2 = @engine.addEntity entity
+
+            expect(entity).to.equal entity2
+            entity.dispose()
+            entity2.dispose()
+
+    describe 'instance.buildEntity()', ->
+
+        beforeEach ->
+            @engine = Engine()
+
+        it 'should be a function', ->
+            expect(@engine).to.respondTo 'buildEntity'
+
         it 'should return new entity instance', ->
-            expect(entity = @engine.addEntity()).to.be.an "object"
+            expect(entity = @engine.buildEntity()).to.be.an "object"
             expect(entity).to.respondTo 'add'
             expect(entity).to.respondTo 'has'
             expect(entity).to.respondTo 'get'
-            expect(entity2 = @engine.addEntity()).to.not.equal entity
+            expect(entity2 = @engine.buildEntity()).to.not.equal entity
             entity.dispose()
             entity2.dispose()
 
         it 'should return entity with components added', ->
             alpha = new @cAlphaComponent
             beta = new @cBetaComponent
-            entity = @engine.addEntity [alpha, beta]
+            entity = @engine.buildEntity [alpha, beta]
 
             expect(entity.size).to.equal 2
             expect(entity.has @cAlphaComponent).to.be.true
@@ -122,13 +150,13 @@ describe 'Engine', ->
             expect(Lill.isAttached @engine.entityList).to.be.true
 
         it 'contains engine owned entities', ->
-            entity1 = @engine.addEntity()
-            entity2 = @engine.addEntity()
+            entity1 = @engine.buildEntity()
+            entity2 = @engine.buildEntity()
             expect(Lill.has @engine.entityList, entity1).to.be.true
             expect(Lill.has @engine.entityList, entity2).to.be.true
 
         it 'removes disposed entities', ->
-            entity = @engine.addEntity()
+            entity = @engine.buildEntity()
             entity.dispose()
             expect(Lill.has @engine.entityList, entity).to.be.false
 
@@ -291,7 +319,7 @@ describe 'Engine', ->
             @nAlphaNode = @engine.getNodeType [@cAlphaComponent]
             @nBetaNode = @engine.getNodeType [@cBetaComponent]
             @nGamaNode = @engine.getNodeType [@cGamaComponent]
-            @eTestEntity = @engine.addEntity [new @cAlphaComponent, new @cBetaComponent]
+            @eTestEntity = @engine.buildEntity [new @cAlphaComponent, new @cBetaComponent]
 
         afterEach ->
             @eTestEntity.dispose()
@@ -472,7 +500,7 @@ describe 'Engine', ->
             expect(@engine.size).to.equal 0
 
         it 'returns number of entities in engine', ->
-            @engine.addEntity() for i in [1..10]
+            @engine.buildEntity() for i in [1..10]
             expect(@engine.size).to.equal 10
 
     describe 'provide()', ->


### PR DESCRIPTION
As discussed in issue #8, I changed `engine.addEntity(entityOrComponents)` to accept either an existing entity or an array of components. Maybe a separate method would be better?
