### PR TITLE
Make the Engine iterable over entities

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "sinon-chai": "https://github.com/FredyC/sinon-chai/tarball/sinon2",
     "testem": "^1.13.0",
     "uglify-js": "^2.4.23",
-    "webpack": "^1.12.9"
+    "webpack": "^1.12.9",
+    "wu": "^2.1.0"
   },
   "dependencies": {
     "async": "^2.1.2",

--- a/test/engine.test.coffee
+++ b/test/engine.test.coffee
@@ -1,5 +1,6 @@
 {Scent, expect, sinon, resetComponentIdentities, mockSystem} = require './setup'
 {Engine, Entity, Component, Symbols} = Scent
+wu = require 'wu'
 
 NoMe = require 'nome'
 Lill = require 'lill'
@@ -160,7 +161,7 @@ describe 'Engine', ->
             entity = new Entity [alpha, beta]
             @engine.addEntity entity
 
-            expect(Lill.has @engine.entityList, entity).to.be.true
+            expect(wu(@engine).has(entity)).to.be.true
             entity.dispose()
 
         it 'should return same entity', ->
@@ -211,25 +212,27 @@ describe 'Engine', ->
             entity.remove 'beta'
             expect(entity.has('beta')).to.be.false
 
-    describe 'instance.entityList', ->
+    describe 'instance[@@iterator]', ->
 
         beforeEach ->
-            @engine = Engine()
+            @engine = new Engine()
+            @entity1 = @engine.buildEntity();
+            @entity2 = @engine.buildEntity();
+            @entity3 = @engine.buildEntity();
 
-        it 'should be an object attached by Lill', ->
-            expect(@engine.entityList).to.be.an "object"
-            expect(Lill.isAttached @engine.entityList).to.be.true
+        it 'should be an iterator function', ->
+            expect(@engine[Symbol.iterator]).to.be.a 'function'
+            iterator = do @engine[Symbol.iterator]
+            expect(iterator).to.have.a.property 'next'
 
-        it 'contains engine owned entities', ->
-            entity1 = @engine.buildEntity()
-            entity2 = @engine.buildEntity()
-            expect(Lill.has @engine.entityList, entity1).to.be.true
-            expect(Lill.has @engine.entityList, entity2).to.be.true
-
-        it 'removes disposed entities', ->
-            entity = @engine.buildEntity()
-            entity.dispose()
-            expect(Lill.has @engine.entityList, entity).to.be.false
+        it 'allows to iterate over existing entities', ->
+            actual = []
+            wu(@engine).forEach((ent) -> actual.push(ent));
+            expect(actual).to.eql([
+                @entity1
+                @entity2
+                @entity3
+            ]);
 
     describe 'instance.addSystem()', ->
 
@@ -556,6 +559,7 @@ describe 'Engine', ->
         it 'returns number of entities in engine', ->
             @engine.buildEntity() for i in [1..10]
             expect(@engine.size).to.equal 10
+
 
     describe 'provide()', ->
 


### PR DESCRIPTION
Iterator is basically just wrapped over linked list to give same performance benefits. Although iterator is based on creating bunch of garbage objects, so it shouldn't be used too often.

The entityList has been marked as deprecated for a public access and will be removed in some future versions.

Closes #22