### PR TITLE
add engine.draw/engine.onDraw to support a better game loop.

### DIFF
--- a/src/engine.coffee
+++ b/src/engine.coffee
@@ -143,6 +143,10 @@ Engine = (initializer) ->
 
 	engine.onUpdate = fast.bind engine$update.notify, engine$update
 
+	engine.draw = NoMe()
+
+	engine.onDraw = fast.bind engine.draw.notify, engine.draw
+
 	## NODES
 
 	# Memory map of node types used by this engine

--- a/test/engine.test.coffee
+++ b/test/engine.test.coffee
@@ -470,6 +470,40 @@ describe 'Engine', ->
             @engine.update(10, 20)
             expect(spy).to.have.been.calledOnce.calledWith(10, 20).calledOn @engine
 
+    describe 'instance.draw()', ->
+
+        beforeEach ->
+            @engine = Engine()
+            @engine.start()
+
+        it 'should be a function', ->
+            expect(@engine).to.respondTo 'draw'
+
+    describe 'instance.onDraw', ->
+
+        beforeEach ->
+            @engine = Engine()
+            @engine.start()
+
+        it 'should be a function', ->
+            expect(@engine).to.respondTo 'onDraw'
+
+        it 'expects callback function', ->
+            {onDraw} = @engine
+            toThrow = (msg, fn) ->
+                expect(fn).to.throw TypeError, /expects function/, msg
+            toThrow 'string', -> onDraw 'str'
+            toThrow 'number', -> onDraw 1
+            toThrow 'bool', -> onDraw true
+            toThrow 'false', -> onDraw false
+            toThrow 'array', -> onDraw []
+            toThrow 'object', -> onDraw {}
+
+        it 'invokes passed callback when engine.draw is invoked', ->
+            @engine.onDraw(spy = sinon.spy())
+            @engine.draw(10)
+            expect(spy).to.have.been.calledOnce.calledWith(10).calledOn @engine
+
     describe 'instance.triggerAction()', ->
 
         beforeEach ->


### PR DESCRIPTION
This PR adds `engine.onDraw` in addition to `engine.onUpdate` for use in systems. This makes it easier to separate physics and render loops. 

Example (using [MainLoop](http://www.npmjs.com/packages/mainloop.js)):

```js
function SomeSystem($engine) {
    $engine.onUpdate(function(delta) {
        // Runs at a fixed timestep, e.g. 20hz or 60hz or 120hz.
    });

    $engine.onDraw(function(interpolationPercentage) {
        // Runs every requestAnimationFrame, e.g. up to 60fps.
    });
}

const engine = new Scent.Engine();
engine.addSystem(SomeSystem);
engine.start();

MainLoop.setUpdate(engine.update)
    .setDraw(engine.draw)
    .start();
```

References:
http://www.isaacsukin.com/news/2015/01/detailed-explanation-javascript-game-loops-and-timing
http://gameprogrammingpatterns.com/game-loop.html